### PR TITLE
Update workflows to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,20 +69,20 @@ jobs:
         NUGET_XMLDOC_MODE: skip
 
     - name: Publish logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: logs-${{ matrix.os_name }}
         path: ./artifacts/log/Release
 
     - name: Publish NuGet packages
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/packages/Release/Shipping
 
     #- name: Publish test results
-    #  uses: actions/upload-artifact@v1
+    #  uses: actions/upload-artifact@v4
     #  if: ${{ always() }}
     #  with:
     #    name: testresults-${{ matrix.os_name }}


### PR DESCRIPTION
Replaced outdated actions with 'actions/upload-artifact@v4' in workflows.